### PR TITLE
Add sample MCP server implementation

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -1,0 +1,86 @@
+# MCP Server
+
+This directory contains a minimal Model Context Protocol (MCP) server written in
+Python. The server is implemented with [FastAPI](https://fastapi.tiangolo.com/)
+and exposes three tools that demonstrate different capabilities you can plug
+into an MCP ecosystem.
+
+## Available tools
+
+| Tool        | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| `echo`      | Echoes a provided message and reports the total character count.            |
+| `timestamp` | Returns the current UTC time in ISO 8601 format and raw epoch seconds.      |
+| `inspiration` | Responds with a random inspirational quote, each tagged with a unique ID. |
+
+## Running locally
+
+1. **Install dependencies**
+
+   ```bash
+   cd mcp_server
+   pip install -e .
+   ```
+
+2. **Start the server**
+
+   ```bash
+   mcp-server
+   ```
+
+   The server listens on `http://0.0.0.0:8000` by default. You can also run it
+   via `uvicorn` directly if you need extra options:
+
+   ```bash
+   uvicorn mcp_server.main:create_app --factory --host 0.0.0.0 --port 8000
+   ```
+
+3. **Interact with the API**
+
+   - List tools:
+
+     ```bash
+     curl http://localhost:8000/tools
+     ```
+
+   - Execute the echo tool:
+
+     ```bash
+     curl -X POST http://localhost:8000/tools/echo \
+       -H "Content-Type: application/json" \
+       -d '{"input": {"message": "Hello MCP"}}'
+     ```
+
+   - The automatic documentation is available at
+     `http://localhost:8000/docs` for a Swagger UI view or
+     `http://localhost:8000/redoc` for ReDoc.
+
+## Project layout
+
+```
+mcp_server/
+├── mcp_server/
+│   ├── __init__.py
+│   ├── main.py
+│   ├── models.py
+│   └── tools.py
+├── pyproject.toml
+└── README.md
+```
+
+## Notes on repository creation
+
+This environment does not have access to GitHub, so a remote repository cannot
+be created automatically. The project is organized locally so that you can push
+it to a new GitHub repository with:
+
+```bash
+git init
+git remote add origin <your-repo-url>
+git add .
+git commit -m "Initial commit"
+git push -u origin main
+```
+
+Replace `<your-repo-url>` with the URL of the GitHub repository you create
+through the GitHub web interface.

--- a/mcp_server/mcp_server/__init__.py
+++ b/mcp_server/mcp_server/__init__.py
@@ -1,0 +1,12 @@
+"""MCP server package."""
+
+from .main import create_app, run
+from .models import Tool, ToolExecutionRequest, ToolExecutionResponse
+
+__all__ = [
+    "Tool",
+    "ToolExecutionRequest",
+    "ToolExecutionResponse",
+    "create_app",
+    "run",
+]

--- a/mcp_server/mcp_server/main.py
+++ b/mcp_server/mcp_server/main.py
@@ -1,0 +1,65 @@
+"""Entry point and API routes for the MCP server."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from .models import Tool, ToolExecutionRequest, ToolExecutionResponse
+from .tools import execute_tool, list_tools
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application instance."""
+
+    app = FastAPI(
+        title="Model Context Protocol Server",
+        description="A minimal MCP server exposing three utility tools.",
+        version="0.1.0",
+    )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/health", summary="Health check", tags=["system"])
+    async def health_check() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/tools", response_model=List[Tool], summary="List available tools", tags=["tools"])
+    async def get_tools() -> List[Tool]:
+        registry = list_tools()
+        return [Tool(name=name, description=entry["description"]) for name, entry in registry.items()]
+
+    @app.post(
+        "/tools/{tool_name}",
+        response_model=ToolExecutionResponse,
+        summary="Execute a tool",
+        tags=["tools"],
+    )
+    async def run_tool(tool_name: str, request: ToolExecutionRequest) -> ToolExecutionResponse:
+        try:
+            result = execute_tool(tool_name, request.input)
+        except KeyError as exc:  # pragma: no cover - simple error branch
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        return ToolExecutionResponse(tool=tool_name, output=result)
+
+    return app
+
+
+def run() -> None:
+    """Run the MCP server using ``uvicorn``."""
+
+    import uvicorn
+
+    uvicorn.run("mcp_server.main:create_app", host="0.0.0.0", port=8000, factory=True)
+
+
+app = create_app()

--- a/mcp_server/mcp_server/models.py
+++ b/mcp_server/mcp_server/models.py
@@ -1,0 +1,36 @@
+"""Pydantic models for the MCP server."""
+
+from datetime import datetime
+from typing import Any, Dict
+
+from pydantic import BaseModel, Field
+
+
+class Tool(BaseModel):
+    """Metadata describing a tool available from the server."""
+
+    name: str = Field(..., description="Unique identifier of the tool.")
+    description: str = Field(..., description="Human readable summary of the tool's purpose.")
+
+
+class ToolExecutionRequest(BaseModel):
+    """Request body used to execute a tool."""
+
+    input: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary JSON payload that parameterizes the tool execution.",
+    )
+
+
+class ToolExecutionResponse(BaseModel):
+    """Standard response returned after running a tool."""
+
+    tool: str = Field(..., description="Identifier of the tool that was invoked.")
+    output: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Structured result payload produced by the tool.",
+    )
+    executed_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp of when the server finished running the tool.",
+    )

--- a/mcp_server/mcp_server/tools.py
+++ b/mcp_server/mcp_server/tools.py
@@ -1,0 +1,97 @@
+"""Collection of tools exposed by the MCP server."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from random import choice
+from typing import Any, Dict
+from uuid import uuid4
+
+
+def echo_tool(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Echo back the supplied payload.
+
+    Parameters
+    ----------
+    payload:
+        Arbitrary JSON-compatible dictionary supplied by the caller.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the original payload and the size of the
+        message body, which can be useful for debugging round-trip latency.
+    """
+
+    message = payload.get("message", "")
+    return {
+        "message": message,
+        "character_count": len(message),
+        "input": payload,
+    }
+
+
+def timestamp_tool(_: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the current UTC timestamp."""
+
+    now = datetime.utcnow()
+    return {
+        "timestamp": now.isoformat() + "Z",
+        "epoch_seconds": now.timestamp(),
+    }
+
+
+_QUOTES = [
+    "Perfection is achieved not when there is nothing more to add, but when there is nothing left to take away.",
+    "In the middle of difficulty lies opportunity.",
+    "Simplicity is the soul of efficiency.",
+    "The best way to predict the future is to invent it.",
+]
+
+
+def inspiration_tool(_: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a random inspirational quote with a unique identifier."""
+
+    quote = choice(_QUOTES)
+    return {
+        "quote": quote,
+        "id": str(uuid4()),
+    }
+
+
+TOOLS = {
+    "echo": {
+        "function": echo_tool,
+        "description": "Echoes the provided message and reports its character length.",
+    },
+    "timestamp": {
+        "function": timestamp_tool,
+        "description": "Returns the current UTC time in ISO format and epoch seconds.",
+    },
+    "inspiration": {
+        "function": inspiration_tool,
+        "description": "Delivers a random inspirational quote with a unique identifier.",
+    },
+}
+
+
+def list_tools() -> Dict[str, Dict[str, Any]]:
+    """Return the registry of available tools."""
+
+    return TOOLS
+
+
+def execute_tool(name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a tool by name.
+
+    Raises
+    ------
+    KeyError
+        If a tool with the supplied ``name`` does not exist.
+    """
+
+    if name not in TOOLS:
+        raise KeyError(f"Unknown tool: {name}")
+
+    tool_func = TOOLS[name]["function"]
+    return tool_func(payload)

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "mcp-server"
+version = "0.1.0"
+description = "A sample Model Context Protocol server exposing three tools."
+requires-python = ">=3.10"
+authors = [
+  { name = "ApiPerfDashboard Team" }
+]
+dependencies = [
+  "fastapi>=0.110.0,<1.0.0",
+  "uvicorn[standard]>=0.29.0,<1.0.0"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4.0"
+]
+
+[project.scripts]
+mcp-server = "mcp_server.main:run"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add a standalone FastAPI-powered MCP server package with a console entrypoint
- define data models, tool registry, and endpoints that expose three tools: echo, timestamp, and inspiration
- document setup, usage, and GitHub publishing steps for the new server project

## Testing
- python -m compileall mcp_server/mcp_server

------
https://chatgpt.com/codex/tasks/task_e_68ce7211d0c08320a8cf29d2cb3135d0