### PR TITLE
Refine API for enterprise readiness

### DIFF
--- a/src/ApiPerfDashboard.Api/Configuration/DatabaseOptions.cs
+++ b/src/ApiPerfDashboard.Api/Configuration/DatabaseOptions.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ApiPerfDashboard.Api.Configuration;
+
+public sealed class DatabaseOptions
+{
+    public const string SectionName = "Database";
+    public const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=metrics;Username=metrics;Password=metrics";
+
+    /// <summary>
+    /// Connection string used to connect to the metrics database.
+    /// </summary>
+    [Required]
+    public string ConnectionString { get; set; } = DefaultConnectionString;
+
+    /// <summary>
+    /// Default timeout applied to SQL commands executed by the API.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int CommandTimeoutSeconds { get; set; } = 30;
+}

--- a/src/ApiPerfDashboard.Api/Data/MetricRepository.cs
+++ b/src/ApiPerfDashboard.Api/Data/MetricRepository.cs
@@ -1,0 +1,99 @@
+using ApiPerfDashboard.Api.Configuration;
+using ApiPerfDashboard.Api.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace ApiPerfDashboard.Api.Data;
+
+public sealed class MetricRepository
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly DatabaseOptions _options;
+    private readonly ILogger<MetricRepository> _logger;
+
+    public MetricRepository(
+        NpgsqlDataSource dataSource,
+        IOptions<DatabaseOptions> options,
+        ILogger<MetricRepository> logger)
+    {
+        _dataSource = dataSource;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task InsertMetricAsync(MetricRequest metric, CancellationToken cancellationToken)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = @"
+            INSERT INTO api_metrics (timestamp, endpoint, api_group, latency_ms, status_code)
+            VALUES (@timestamp, @endpoint, @api_group, @latency_ms, @status_code);";
+        command.CommandTimeout = _options.CommandTimeoutSeconds;
+
+        command.Parameters.AddWithValue("@timestamp", metric.Timestamp.UtcDateTime);
+        command.Parameters.AddWithValue("@endpoint", metric.Endpoint);
+        command.Parameters.AddWithValue("@api_group", metric.ApiGroup ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@latency_ms", metric.LatencyMs);
+        command.Parameters.AddWithValue("@status_code", metric.StatusCode);
+
+        _logger.LogDebug(
+            "Writing metric for {Endpoint} (status: {StatusCode}, latency: {Latency}ms)",
+            metric.Endpoint,
+            metric.StatusCode,
+            metric.LatencyMs);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<MetricSummaryRow>> GetSummaryAsync(
+        MetricSummaryQuery query,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        var sql = new System.Text.StringBuilder(@"
+            SELECT endpoint,
+                   api_group,
+                   AVG(latency_ms) AS avg_latency,
+                   100.0 * SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) / NULLIF(COUNT(*), 0) AS error_pct,
+                   COUNT(*) AS total
+            FROM api_metrics
+            WHERE timestamp BETWEEN @from AND @to");
+
+        command.Parameters.AddWithValue("@from", query.From.UtcDateTime);
+        command.Parameters.AddWithValue("@to", query.To.UtcDateTime);
+
+        if (!string.IsNullOrWhiteSpace(query.ApiGroup))
+        {
+            sql.Append(" AND api_group = @api_group");
+            command.Parameters.AddWithValue("@api_group", query.ApiGroup);
+        }
+
+        sql.Append(" GROUP BY endpoint, api_group ORDER BY endpoint, api_group");
+        command.CommandText = sql.ToString();
+        command.CommandTimeout = _options.CommandTimeoutSeconds;
+
+        var rows = new List<MetricSummaryRow>();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var endpoint = reader.GetString(0);
+            var apiGroup = await reader.IsDBNullAsync(1, cancellationToken)
+                ? null
+                : reader.GetString(1);
+            var avgLatency = reader.IsDBNull(2) ? 0d : reader.GetDouble(2);
+            var errorPct = reader.IsDBNull(3) ? 0d : reader.GetDouble(3);
+            var total = reader.GetInt64(4);
+
+            rows.Add(new MetricSummaryRow(
+                endpoint,
+                apiGroup,
+                Math.Round(avgLatency, 2, MidpointRounding.AwayFromZero),
+                Math.Round(errorPct, 2, MidpointRounding.AwayFromZero),
+                total));
+        }
+
+        return rows;
+    }
+}

--- a/src/ApiPerfDashboard.Api/HealthChecks/MetricsDbHealthCheck.cs
+++ b/src/ApiPerfDashboard.Api/HealthChecks/MetricsDbHealthCheck.cs
@@ -1,0 +1,47 @@
+using ApiPerfDashboard.Api.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace ApiPerfDashboard.Api.HealthChecks;
+
+public sealed class MetricsDbHealthCheck : IHealthCheck
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly DatabaseOptions _options;
+    private readonly ILogger<MetricsDbHealthCheck> _logger;
+
+    public MetricsDbHealthCheck(
+        NpgsqlDataSource dataSource,
+        IOptions<DatabaseOptions> options,
+        ILogger<MetricsDbHealthCheck> logger)
+    {
+        _dataSource = dataSource;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+            await using var command = connection.CreateCommand();
+            command.CommandText = "SELECT 1";
+            command.CommandTimeout = _options.CommandTimeoutSeconds;
+            await command.ExecuteScalarAsync(cancellationToken);
+
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to verify connectivity to the metrics database.");
+            return HealthCheckResult.Unhealthy(
+                "Unable to connect to the metrics database.",
+                ex);
+        }
+    }
+}

--- a/src/ApiPerfDashboard.Api/Infrastructure/HealthCheckResponseWriter.cs
+++ b/src/ApiPerfDashboard.Api/Infrastructure/HealthCheckResponseWriter.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ApiPerfDashboard.Api.Infrastructure;
+
+public static class HealthCheckResponseWriter
+{
+    public static Task WriteResponse(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        var payload = new
+        {
+            status = report.Status.ToString(),
+            duration = report.TotalDuration,
+            results = report.Entries.Select(pair => new
+            {
+                name = pair.Key,
+                status = pair.Value.Status.ToString(),
+                description = pair.Value.Description,
+                duration = pair.Value.Duration,
+                error = pair.Value.Exception?.Message
+            })
+        };
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload, new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        }));
+    }
+}

--- a/src/ApiPerfDashboard.Api/Infrastructure/MetricSchemaInitializer.cs
+++ b/src/ApiPerfDashboard.Api/Infrastructure/MetricSchemaInitializer.cs
@@ -1,0 +1,47 @@
+using ApiPerfDashboard.Api.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+
+namespace ApiPerfDashboard.Api.Infrastructure;
+
+public sealed class MetricSchemaInitializer : IHostedService
+{
+    private readonly NpgsqlDataSource _dataSource;
+    private readonly DatabaseOptions _options;
+    private readonly ILogger<MetricSchemaInitializer> _logger;
+
+    private const string CreateTableSql = @"
+        CREATE TABLE IF NOT EXISTS api_metrics (
+            id SERIAL PRIMARY KEY,
+            timestamp TIMESTAMPTZ NOT NULL,
+            endpoint TEXT NOT NULL,
+            api_group TEXT NULL,
+            latency_ms INT NOT NULL,
+            status_code INT NOT NULL
+        );";
+
+    public MetricSchemaInitializer(
+        NpgsqlDataSource dataSource,
+        IOptions<DatabaseOptions> options,
+        ILogger<MetricSchemaInitializer> logger)
+    {
+        _dataSource = dataSource;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Ensuring the api_metrics table exists.");
+        await using var connection = await _dataSource.OpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = CreateTableSql;
+        command.CommandTimeout = _options.CommandTimeoutSeconds;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        _logger.LogInformation("Database schema check completed successfully.");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/ApiPerfDashboard.Api/Models/MetricIngestedResponse.cs
+++ b/src/ApiPerfDashboard.Api/Models/MetricIngestedResponse.cs
@@ -1,0 +1,6 @@
+namespace ApiPerfDashboard.Api.Models;
+
+public sealed record MetricIngestedResponse(
+    DateTimeOffset Timestamp,
+    string Endpoint,
+    string? ApiGroup);

--- a/src/ApiPerfDashboard.Api/Models/MetricRequest.cs
+++ b/src/ApiPerfDashboard.Api/Models/MetricRequest.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ApiPerfDashboard.Api.Models;
+
+public sealed record MetricRequest : IValidatableObject
+{
+    [Required]
+    public DateTimeOffset Timestamp { get; init; } = DateTimeOffset.UtcNow;
+
+    [Required]
+    [StringLength(256)]
+    public string Endpoint { get; init; } = string.Empty;
+
+    [StringLength(128)]
+    public string? ApiGroup { get; init; }
+        = null;
+
+    [Range(0, int.MaxValue)]
+    public int LatencyMs { get; init; }
+        = 0;
+
+    [Range(100, 599)]
+    public int StatusCode { get; init; }
+        = 200;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (Timestamp > DateTimeOffset.UtcNow.AddMinutes(5))
+        {
+            yield return new ValidationResult(
+                "The metric timestamp cannot be more than five minutes in the future.",
+                new[] { nameof(Timestamp) });
+        }
+
+        if (!string.IsNullOrWhiteSpace(Endpoint) && !Endpoint.StartsWith('/'))
+        {
+            yield return new ValidationResult(
+                "Endpoint values should be relative paths and start with '/'.",
+                new[] { nameof(Endpoint) });
+        }
+    }
+}

--- a/src/ApiPerfDashboard.Api/Models/MetricSummaryQuery.cs
+++ b/src/ApiPerfDashboard.Api/Models/MetricSummaryQuery.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace ApiPerfDashboard.Api.Models;
+
+public sealed record MetricSummaryQuery : IValidatableObject
+{
+    private static readonly TimeSpan DefaultLookback = TimeSpan.FromHours(24);
+
+    [Required]
+    public DateTimeOffset From { get; init; } = DateTimeOffset.UtcNow.Subtract(DefaultLookback);
+
+    [Required]
+    public DateTimeOffset To { get; init; } = DateTimeOffset.UtcNow;
+
+    [StringLength(128)]
+    public string? ApiGroup { get; init; }
+        = null;
+
+    public static MetricSummaryQuery Create(DateTimeOffset? from, DateTimeOffset? to, string? apiGroup)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new MetricSummaryQuery
+        {
+            From = (from ?? now.Subtract(DefaultLookback)).ToUniversalTime(),
+            To = (to ?? now).ToUniversalTime(),
+            ApiGroup = string.IsNullOrWhiteSpace(apiGroup) ? null : apiGroup
+        };
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (From > To)
+        {
+            yield return new ValidationResult(
+                "The 'from' value must be earlier than the 'to' value.",
+                new[] { nameof(From), nameof(To) });
+        }
+    }
+}

--- a/src/ApiPerfDashboard.Api/Models/MetricSummaryRow.cs
+++ b/src/ApiPerfDashboard.Api/Models/MetricSummaryRow.cs
@@ -1,0 +1,8 @@
+namespace ApiPerfDashboard.Api.Models;
+
+public sealed record MetricSummaryRow(
+    string Endpoint,
+    string? ApiGroup,
+    double AverageLatencyMs,
+    double ErrorPercentage,
+    long TotalRequests);

--- a/src/ApiPerfDashboard.Api/Program.cs
+++ b/src/ApiPerfDashboard.Api/Program.cs
@@ -1,90 +1,118 @@
+using ApiPerfDashboard.Api.Configuration;
+using ApiPerfDashboard.Api.Data;
+using ApiPerfDashboard.Api.HealthChecks;
+using ApiPerfDashboard.Api.Infrastructure;
+using ApiPerfDashboard.Api.Models;
+using ApiPerfDashboard.Api.Validation;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using Npgsql;
-using System.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddProblemDetails();
+
+builder.Services
+    .AddOptions<DatabaseOptions>()
+    .BindConfiguration(DatabaseOptions.SectionName)
+    .Configure(options =>
+    {
+        if (string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            options.ConnectionString = builder.Configuration.GetConnectionString("Postgres")
+                ?? DatabaseOptions.DefaultConnectionString;
+        }
+    })
+    .ValidateDataAnnotations()
+    .Validate(
+        options => !string.IsNullOrWhiteSpace(options.ConnectionString),
+        "A database connection string must be provided.")
+    .Validate(
+        options => options.CommandTimeoutSeconds > 0,
+        "Database command timeout must be greater than zero.")
+    .ValidateOnStart();
+
+builder.Services.AddSingleton(sp =>
+{
+    var options = sp.GetRequiredService<IOptions<DatabaseOptions>>().Value;
+    var dataSourceBuilder = new NpgsqlDataSourceBuilder(options.ConnectionString)
+    {
+        DefaultCommandTimeout = options.CommandTimeoutSeconds
+    };
+
+    dataSourceBuilder.UseLoggerFactory(sp.GetRequiredService<ILoggerFactory>());
+    return dataSourceBuilder.Build();
+});
+
+builder.Services.AddScoped<MetricRepository>();
+builder.Services.AddHostedService<MetricSchemaInitializer>();
+builder.Services.AddHealthChecks()
+    .AddCheck<MetricsDbHealthCheck>("metrics-database", tags: new[] { "ready" });
 
 var app = builder.Build();
 
+app.UseExceptionHandler();
+app.UseStatusCodePages();
 app.UseSwagger();
 app.UseSwaggerUI();
+app.UseHttpsRedirection();
 
-string connStr = builder.Configuration.GetConnectionString("Postgres") ??
-    "Host=localhost;Port=5432;Database=metrics;Username=metrics;Password=metrics";
+var metricsGroup = app.MapGroup("/metrics")
+    .WithTags("Metrics")
+    .WithOpenApi();
 
-app.MapPost("/metrics", async (Metric m) =>
+metricsGroup.MapPost(string.Empty, async Task<IResult> (
+        MetricRequest request,
+        MetricRepository repository,
+        CancellationToken cancellationToken) =>
+    {
+        var errors = ValidationExtensions.ValidateObject(request);
+        if (errors.Count > 0)
+        {
+            return Results.ValidationProblem(errors);
+        }
+
+        await repository.InsertMetricAsync(request, cancellationToken);
+        var response = new MetricIngestedResponse(request.Timestamp, request.Endpoint, request.ApiGroup);
+        return Results.Created($"/metrics?endpoint={Uri.EscapeDataString(request.Endpoint)}", response);
+    })
+    .Produces<MetricIngestedResponse>(StatusCodes.Status201Created)
+    .ProducesValidationProblem()
+    .WithName("IngestMetric")
+    .WithSummary("Ingest a single API performance datapoint.")
+    .WithDescription("Accepts latency, status code and metadata for an API call.");
+
+metricsGroup.MapGet("/summary", async Task<IResult> (
+        DateTimeOffset? from,
+        DateTimeOffset? to,
+        string? apiGroup,
+        MetricRepository repository,
+        CancellationToken cancellationToken) =>
+    {
+        var query = MetricSummaryQuery.Create(from, to, apiGroup);
+        var errors = ValidationExtensions.ValidateObject(query);
+        if (errors.Count > 0)
+        {
+            return Results.ValidationProblem(errors);
+        }
+
+        var rows = await repository.GetSummaryAsync(query, cancellationToken);
+        return Results.Ok(rows);
+    })
+    .Produces<IReadOnlyList<MetricSummaryRow>>(StatusCodes.Status200OK)
+    .ProducesValidationProblem()
+    .WithName("GetMetricSummary")
+    .WithSummary("Retrieve aggregated performance metrics.")
+    .WithDescription("Returns average latency, error percentage and volume by endpoint.");
+
+app.MapGet("/health/live", () => Results.Ok(new { status = "Healthy" }));
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
-    await using var conn = new NpgsqlConnection(connStr);
-    await conn.OpenAsync();
-
-    // Create table if not exists
-    var createSql = @"
-        CREATE TABLE IF NOT EXISTS api_metrics (
-            id SERIAL PRIMARY KEY,
-            timestamp TIMESTAMPTZ NOT NULL,
-            endpoint TEXT NOT NULL,
-            api_group TEXT,
-            latency_ms INT NOT NULL,
-            status_code INT NOT NULL
-        );";
-    await using (var createCmd = new NpgsqlCommand(createSql, conn))
-    {
-        await createCmd.ExecuteNonQueryAsync();
-    }
-
-    // Insert row
-    var insertSql = "INSERT INTO api_metrics (timestamp, endpoint, api_group, latency_ms, status_code) VALUES (@ts, @ep, @grp, @lat, @sc)";
-    await using (var cmd = new NpgsqlCommand(insertSql, conn))
-    {
-        cmd.Parameters.AddWithValue("@ts", m.Timestamp);
-        cmd.Parameters.AddWithValue("@ep", m.Endpoint);
-        cmd.Parameters.AddWithValue("@grp", m.ApiGroup ?? (object)DBNull.Value);
-        cmd.Parameters.AddWithValue("@lat", m.LatencyMs);
-        cmd.Parameters.AddWithValue("@sc", m.StatusCode);
-        await cmd.ExecuteNonQueryAsync();
-    }
-
-    return Results.Ok(new { saved = true });
-})
-.WithName("PostMetric")
-.WithOpenApi();
-
-app.MapGet("/metrics/summary", async (DateTime from, DateTime to) =>
-{
-    await using var conn = new NpgsqlConnection(connStr);
-    await conn.OpenAsync();
-
-    var sql = @"
-        SELECT endpoint,
-               AVG(latency_ms) as avg_latency,
-               100.0 * SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END) / COUNT(*) as error_pct,
-               COUNT(*) as total
-        FROM api_metrics
-        WHERE timestamp BETWEEN @from AND @to
-        GROUP BY endpoint
-        ORDER BY endpoint";
-    await using var cmd = new NpgsqlCommand(sql, conn);
-    cmd.Parameters.AddWithValue("@from", from);
-    cmd.Parameters.AddWithValue("@to", to);
-
-    var result = new List<object>();
-    await using var reader = await cmd.ExecuteReaderAsync();
-    while (await reader.ReadAsync())
-    {
-        result.Add(new {
-            Endpoint = reader["endpoint"].ToString(),
-            AvgLatency = reader["avg_latency"],
-            ErrorPct = reader["error_pct"],
-            Count = reader["total"]
-        });
-    }
-    return Results.Ok(result);
-})
-.WithName("GetSummary")
-.WithOpenApi();
+    Predicate = check => check.Tags.Contains("ready"),
+    ResponseWriter = HealthCheckResponseWriter.WriteResponse
+});
 
 app.Run();
-
-record Metric(DateTime Timestamp, string Endpoint, int LatencyMs, int StatusCode, string? ApiGroup);

--- a/src/ApiPerfDashboard.Api/Validation/ValidationExtensions.cs
+++ b/src/ApiPerfDashboard.Api/Validation/ValidationExtensions.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace ApiPerfDashboard.Api.Validation;
+
+public static class ValidationExtensions
+{
+    public static Dictionary<string, string[]> ValidateObject<T>(T instance)
+        where T : class
+    {
+        var results = new List<ValidationResult>();
+        var context = new ValidationContext(instance);
+        Validator.TryValidateObject(instance, context, results, validateAllProperties: true);
+
+        return results
+            .SelectMany(result => result.MemberNames.DefaultIfEmpty(string.Empty),
+                (result, memberName) => new { memberName, result.ErrorMessage })
+            .Where(item => !string.IsNullOrWhiteSpace(item.ErrorMessage))
+            .GroupBy(item => item.memberName)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .Select(item => item.ErrorMessage!)
+                    .Distinct()
+                    .ToArray());
+    }
+}


### PR DESCRIPTION
## Summary
- encapsulate Postgres configuration behind validated options and reusable data source
- add repository, schema initializer, and request validation to ingest and summarize metrics safely
- expose readiness and liveness health endpoints with structured responses

## Testing
- `dotnet build` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce74fa98848320b5f299551bb48cfa